### PR TITLE
Evaluate environment variables in params block

### DIFF
--- a/twkit/utils.py
+++ b/twkit/utils.py
@@ -95,7 +95,7 @@ def create_temp_yaml(params_dict):
         pass
 
     def quoted_str_representer(dumper, data):
-        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
 
     yaml.add_representer(quoted_str, quoted_str_representer)
     for k, v in params_dict.items():

--- a/twkit/utils.py
+++ b/twkit/utils.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import os
 import yaml
 from urllib.parse import urlparse
 
@@ -98,9 +99,7 @@ def create_temp_yaml(params_dict):
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
 
     yaml.add_representer(quoted_str, quoted_str_representer)
-    for k, v in params_dict.items():
-        if k == "outdir" and isinstance(v, str):
-            params_dict[k] = quoted_str(v)
+    params_dict = {k: os.path.expandvars(v) for k, v in params_dict.items()}
 
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".yaml"


### PR DESCRIPTION
Changes:
 - Temp YAML is created with double quotes which should allow shell to evaluate environment variables.
 - Environment variables in YAML are evaluated while creating tmp file which should allow dynamic naming. 
 - Only applies to params.

Fixes #38
