### PR TITLE
Support multiple input files

### DIFF
--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import mock_open, patch
+from twkit import helper
+
+mocked_yaml = """
+datasets:
+  - name: 'test_dataset1'
+    description: 'My test dataset 1'
+    header: true
+    workspace: 'my_organization/my_workspace'
+    file-path: './examples/yaml/datasets/samples.csv'
+    overwrite: True
+"""
+
+mocked_file = mock_open(read_data=mocked_yaml)
+
+
+class TestYamlParserFunctions(unittest.TestCase):
+    @patch("builtins.open", mocked_file)
+    def test_parse_datasets_yaml(self):
+        result = helper.parse_all_yaml(["test_path.yaml"])
+        expected_block_output = [
+            {
+                "cmd_args": [
+                    "--header",
+                    "./examples/yaml/datasets/samples.csv",
+                    "--name",
+                    "test_dataset1",
+                    "--workspace",
+                    "my_organization/my_workspace",
+                    "--description",
+                    "My test dataset 1",
+                ],
+                "overwrite": True,
+            }
+        ]
+
+        self.assertIn("datasets", result)
+        self.assertEqual(result["datasets"], expected_block_output)
+
+
+# TODO: add more tests for other functions in helper.py

--- a/twkit/helper.py
+++ b/twkit/helper.py
@@ -8,7 +8,6 @@ from twkit import utils
 
 
 def parse_yaml_block(yaml_data, block_name):
-
     # Get the name of the specified block/resource.
     block = yaml_data.get(block_name)
 

--- a/twkit/helper.py
+++ b/twkit/helper.py
@@ -7,13 +7,14 @@ import yaml
 from twkit import utils
 
 
-def parse_yaml_block(file_path, block_name):
-    # Load the YAML file.
-    with open(file_path, "r") as f:
-        data = yaml.safe_load(f)
+def parse_yaml_block(yaml_data, block_name):
 
-    # Get the specified block.
-    block = data.get(block_name)
+    # Get the name of the specified block/resource.
+    block = yaml_data.get(block_name)
+
+    # If block is not found in the YAML, return an empty list.
+    if not block:
+        return block_name, []
 
     # Initialize an empty list to hold the lists of command line arguments.
     cmd_args_list = []
@@ -38,7 +39,20 @@ def parse_yaml_block(file_path, block_name):
     return block_name, cmd_args_list
 
 
-def parse_all_yaml(file_path, block_names):
+def parse_all_yaml(file_paths):
+    # If multiple yamls, merge them into one dictionary
+    merged_data = {}
+
+    for file_path in file_paths:
+        with open(file_path, "r") as f:
+            data = yaml.safe_load(f)
+            # Update merged_data with the content of this file
+            merged_data.update(data)
+
+    # Get the names of all the blocks/resources to create in the merged data.
+    block_names = list(merged_data.keys())
+
+    # Define the order in which the resources should be created.
     resource_order = [
         "organizations",
         "teams",
@@ -57,10 +71,9 @@ def parse_all_yaml(file_path, block_names):
 
     # Iterate over each block name in the desired order.
     for block_name in resource_order:
-        # Check if the block name is present in the provided block_names list
         if block_name in block_names:
-            # Parse the block and add its command arguments to the dictionary.
-            block_name, cmd_args_list = parse_yaml_block(file_path, block_name)
+            # Parse the block and add its command line arguments to the dictionary.
+            block_name, cmd_args_list = parse_yaml_block(merged_data, block_name)
             cmd_args_dict[block_name] = cmd_args_list
 
     # Return the dictionary of command arguments.


### PR DESCRIPTION
Adds support for passing multiple yaml files to `twkit` in no particular order of resource creation.

To test: 
Create 3 yamls:
```
datasets:
  - name: 'test_dataset1' 
    description: 'My test dataset 1'  
    header: true 
    workspace: 'twkit-e2e/showcase'
    file-path: './examples/yaml/datasets/rnaseq_samples.csv'
    overwrite: True  
```
```
launch:
  - name: 'nf-core-rnaseq-launchpad'
    workspace: 'twkit-e2e/showcase'
    pipeline: 'nf-core-rnaseq'
```
```
pipelines:
  - name: 'nf-core-rnaseq'
    url: 'https://github.com/nf-core/rnaseq'
    workspace: 'twkit-e2e/showcase'
    description: 'RNA sequencing analysis pipeline using STAR, RSEM, HISAT2 or Salmon with gene/isoform counts and extensive quality control.'
    compute-env: 'seqera_aws_ireland_fusionv2_nvme'
    work-dir: 's3://seqeralabs-showcase'
    profile: 'test'
    revision: '3.12.0'
    params:
      outdir: 's3://seqeralabs-showcase/nf-core-rnaseq/results'
    config: './examples/yaml/pipelines/nextflow.config'
    pre-run: './examples/yaml/pipelines/pre_run.txt'
    overwrite: True
 ```
 
 Pass to `twkit` with:
 ```
 twkit launch.yaml pipelines.yaml datasets.yaml
 ```
 
 Will be parsed in order of datasets -> pipelines -> launch (as defined in `resource_order` in `parse_all_yaml()`
 
 Also moves opening and loading of yamls into `helper.parse_all_yaml()` instead of in `cli.py`.