### PR TITLE
Recursively delete from yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ You will need to have an account on Nextflow Tower (see [Plans and pricing](http
    twkit hello-world-config.yml
    ```
 
-   <b>Note</b>: The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with the `--insecure` flag. For example:
+   <b>Note</b>: The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with `--cli` followed by the `--insecure` flag. For example:
 
    ```
-   twkit hello-world-config.yml --insecure
+   twkit hello-world-config.yml --cli --insecure
    ```
 
 3. Login to your Tower instance and check the Runs page in the appropriate Workspace for the pipeline you just launched!

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import mock_open, patch
+from twkit import helper
+
+mocked_yaml = """
+datasets:
+  - name: 'test_dataset1'
+    description: 'My test dataset 1'
+    header: true
+    workspace: 'my_organization/my_workspace'
+    file-path: './examples/yaml/datasets/samples.csv'
+    overwrite: True
+"""
+
+mocked_file = mock_open(read_data=mocked_yaml)
+
+
+class TestYamlParserFunctions(unittest.TestCase):
+    @patch("builtins.open", mocked_file)
+    def test_parse_datasets_yaml(self):
+        result = helper.parse_all_yaml(["test_path.yaml"])
+        expected_block_output = [
+            {
+                "cmd_args": [
+                    "--header",
+                    "./examples/yaml/datasets/samples.csv",
+                    "--name",
+                    "test_dataset1",
+                    "--workspace",
+                    "my_organization/my_workspace",
+                    "--description",
+                    "My test dataset 1",
+                ],
+                "overwrite": True,
+            }
+        ]
+
+        self.assertIn("datasets", result)
+        self.assertEqual(result["datasets"], expected_block_output)
+
+
+# TODO: add more tests for other functions in helper.py

--- a/twkit/cli.py
+++ b/twkit/cli.py
@@ -5,7 +5,6 @@ the required options for each resource based on the Tower CLI.
 """
 import argparse
 import logging
-import time
 
 from pathlib import Path
 from twkit import tower, helper, overwrite
@@ -134,7 +133,6 @@ def main():
             try:
                 # Run the 'tw' methods for each block
                 block_manager.handle_block(block, args, destroy=options.delete)
-                time.sleep(3)
             except ResourceExistsError as e:
                 logging.error(e)
                 continue

--- a/twkit/cli.py
+++ b/twkit/cli.py
@@ -44,7 +44,7 @@ def parse_args():
         "--cli",
         dest="cli_args",
         nargs=argparse.REMAINDER,
-        help="Additional arguments to pass to the Tower CLI",
+        help="Additional arguments to pass to the Tower CLI (e.g. '--insecure')",
     )
     return parser.parse_args()
 

--- a/twkit/helper.py
+++ b/twkit/helper.py
@@ -8,7 +8,6 @@ from twkit import utils
 
 
 def parse_yaml_block(yaml_data, block_name):
-
     # Get the name of the specified block/resource.
     block = yaml_data.get(block_name)
 
@@ -39,7 +38,7 @@ def parse_yaml_block(yaml_data, block_name):
     return block_name, cmd_args_list
 
 
-def parse_all_yaml(file_paths):
+def parse_all_yaml(file_paths, destroy=False):
     # If multiple yamls, merge them into one dictionary
     merged_data = {}
 
@@ -66,6 +65,11 @@ def parse_all_yaml(file_paths):
         "pipelines",
         "launch",
     ]
+
+    # Reverse the order of resources if destroy is True
+    if destroy:
+        resource_order = resource_order[:-1][::-1]
+
     # Initialize an empty dictionary to hold all the command arguments.
     cmd_args_dict = {}
 

--- a/twkit/helper.py
+++ b/twkit/helper.py
@@ -7,13 +7,14 @@ import yaml
 from twkit import utils
 
 
-def parse_yaml_block(file_path, block_name):
-    # Load the YAML file.
-    with open(file_path, "r") as f:
-        data = yaml.safe_load(f)
+def parse_yaml_block(yaml_data, block_name):
 
-    # Get the specified block.
-    block = data.get(block_name)
+    # Get the name of the specified block/resource.
+    block = yaml_data.get(block_name)
+
+    # If block is not found in the YAML, return an empty list.
+    if not block:
+        return block_name, []
 
     # Initialize an empty list to hold the lists of command line arguments.
     cmd_args_list = []
@@ -38,7 +39,20 @@ def parse_yaml_block(file_path, block_name):
     return block_name, cmd_args_list
 
 
-def parse_all_yaml(file_path, block_names):
+def parse_all_yaml(file_paths):
+    # If multiple yamls, merge them into one dictionary
+    merged_data = {}
+
+    for file_path in file_paths:
+        with open(file_path, "r") as f:
+            data = yaml.safe_load(f)
+            # Update merged_data with the content of this file
+            merged_data.update(data)
+
+    # Get the names of all the blocks/resources to create in the merged data.
+    block_names = list(merged_data.keys())
+
+    # Define the order in which the resources should be created.
     resource_order = [
         "organizations",
         "teams",
@@ -57,10 +71,9 @@ def parse_all_yaml(file_path, block_names):
 
     # Iterate over each block name in the desired order.
     for block_name in resource_order:
-        # Check if the block name is present in the provided block_names list
         if block_name in block_names:
-            # Parse the block and add its command arguments to the dictionary.
-            block_name, cmd_args_list = parse_yaml_block(file_path, block_name)
+            # Parse the block and add its command line arguments to the dictionary.
+            block_name, cmd_args_list = parse_yaml_block(merged_data, block_name)
             cmd_args_dict[block_name] = cmd_args_list
 
     # Return the dictionary of command arguments.

--- a/twkit/overwrite.py
+++ b/twkit/overwrite.py
@@ -63,7 +63,7 @@ class Overwrite:
             },
         }
 
-    def handle_overwrite(self, block, args, overwrite=False):
+    def handle_overwrite(self, block, args, overwrite=False, destroy=False):
         """
         Handles overwrite functionality for Tower resources and
         calling the 'tw delete' method with the correct args.
@@ -89,13 +89,16 @@ class Overwrite:
                     self.block_operations["participants"]["name_key"] = "email"
 
             if self.check_resource_exists(operation["name_key"], tw_args):
-                # if resource exists, delete
+                # if resource exists and overwrite is true, delete
                 if overwrite:
                     logging.debug(
                         f" The attempted {block} resource already exists."
                         " Overwriting.\n"
                     )
-                    self._delete_resource(block, operation, tw_args)
+                    self.delete_resource(block, operation, tw_args)
+                elif destroy:
+                    logging.debug(f" Deleting the {block} resource.")
+                    self.delete_resource(block, operation, tw_args)
                 else:  # return an error if resource exists, overwrite=False
                     raise ResourceExistsError(
                         f" The {block} resource already exists and"
@@ -217,7 +220,7 @@ class Overwrite:
         """
         return utils.check_if_exists(self.cached_jsondata, name_key, tw_args["name"])
 
-    def _delete_resource(self, block, operation, tw_args):
+    def delete_resource(self, block, operation, tw_args):
         """
         Delete a resource in Tower by calling the delete() method and
         arguments defined in the operation dictionary.


### PR DESCRIPTION
Adds support for a `--delete` flag where if supplied to `twkit` with YAML(s), will recursively delete all resources instead of create them. For example, if you create organization -> workspace -> team -> credentials -> compute-env -> pipeline. When supplying `twkit file.yaml --delete`, the tool will delete pipeline -> compute-env -> credentials -> team -> workspace -> organization. 

Leverages existing functionality we had for deleting resources in `overwrite.py`, specifically the `delete_resource()` method called in `handle_overwrite`.