### PR TITLE
Relax python dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - conda-forge::python=3.10.9
+  - conda-forge::python>=3.8
   - conda-forge::pyyaml=6.0
   - bioconda::tower-cli=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_packages, setup
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
The python dependency is too tight right now, I couldn't get the environment to create on the mac (even with CONDA_SUBDIR):

```
Could not solve for environment specs
The following package could not be installed
└─ python 3.10.9*  is uninstallable because it requires
   └─ libffi >=3.4,<4.0a0 , which conflicts with any installable versions previously reported.
```

From the README we just need 3.8 minimum, right? 

(this did work for me)