### PR TITLE
Ignore existing participant error

### DIFF
--- a/tests/unit/test_tower.py
+++ b/tests/unit/test_tower.py
@@ -61,6 +61,20 @@ class TestTower(unittest.TestCase):
             with self.assertRaises(tower.ResourceExistsError):
                 command("arg1", "arg2")
 
+    def test_resource_exists_error_alt_error(self):
+        with patch("subprocess.Popen") as mock_subprocess:
+            # Simulate a 'resource already exists' error
+            mock_subprocess.return_value.communicate.return_value = (
+                b"ERROR: Already a participant",
+                b"",
+            )
+
+            command = getattr(self.tw, "pipelines")
+
+            # Check that the error is raised
+            with self.assertRaises(tower.ResourceExistsError):
+                command("arg1", "arg2")
+
     def test_resource_creation_error(self):
         with patch("subprocess.Popen") as mock_subprocess:
             # Simulate a 'resource creation failed' error

--- a/twkit/tower.py
+++ b/twkit/tower.py
@@ -77,7 +77,9 @@ class Tower:
 
         # Error handling for stdout
         if stdout:
-            if re.search(r"ERROR: .* already exists", stdout):
+            if re.search(
+                r"ERROR: .*already (exists|a participant)", stdout, flags=re.IGNORECASE
+            ):
                 raise ResourceExistsError(
                     " Resource already exists and will not be created."
                     " Please set 'overwrite: true'\n"


### PR DESCRIPTION
Adding a participant produced a slightly different error message.

From:
Resource already exists

To:
Already a participant

Changing to case insensitive and adding an extra regex group caught it.
Added additional test for new scenario.