### PR TITLE
refactor: enclose tw cli options in double quotes to twkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ You will need to have an account on Nextflow Tower (see [Plans and pricing](http
    <b>Note</b>: The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with `--cli` followed by the `--insecure` flag. For example:
 
    ```
-   twkit hello-world-config.yml --cli --insecure
+   twkit hello-world-config.yml --cli "--insecure"
    ```
 
-   To use an SSL certificate that it is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option to `twkit` as you would to `tw`, preceded by `--cli` flag to indicate use of `tw` specific CLI options. For example:
+   To use an SSL certificate that it is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option enclosed in double quotes to `twkit` as you would to `tw`, preceded by `--cli` flag to indicate use of `tw` specific CLI options. For example:
 
    ```
-   twkit hello-world-config.yml --cli -Djavax.net.ssl.trustStore=/absolute/path/to/cacerts
+   twkit hello-world-config.yml --cli "-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts"
 
    ```
 

--- a/twkit/cli.py
+++ b/twkit/cli.py
@@ -43,8 +43,10 @@ def parse_args():
     parser.add_argument(
         "--cli",
         dest="cli_args",
-        nargs=argparse.REMAINDER,
-        help="Additional arguments to pass to the Tower CLI (e.g. '--insecure')",
+        type=str,
+        nargs="+",
+        help="Additional arguments to pass to the Tower"
+        "CLI enclosed in double quotes (e.g. '--cli \"--insecure\"')",
     )
     return parser.parse_args()
 
@@ -110,8 +112,9 @@ class BlockParser:
 def main():
     options = parse_args()
     logging.basicConfig(level=options.log_level)
+    cli_args_list = options.cli_args[0].split()
 
-    tw = tower.Tower(cli_args=options.cli_args, dryrun=options.dryrun)
+    tw = tower.Tower(cli_args=cli_args_list, dryrun=options.dryrun)
     block_manager = BlockParser(
         tw,
         [


### PR DESCRIPTION
Use `--cli "--insecure"` instead of `--cli --insecure` for clarity and better readability