### PR TITLE
fix: provide better error msg for resource exists

### DIFF
--- a/twkit/tower.py
+++ b/twkit/tower.py
@@ -82,8 +82,8 @@ class Tower:
         if stdout:
             if re.search(r"ERROR: .* already exists", stdout):
                 raise ResourceExistsError(
-                    " Resource already exists and will not be created."
-                    " Please set 'overwrite: true'\n"
+                    " Resource already exists and cannot be created."
+                    " Please delete first or if using a YAML, set 'overwrite: true'\n"
                 )
             elif re.search(r"ERROR: .*", stdout):
                 raise ResourceCreationError(


### PR DESCRIPTION
Re #53

Add a more descriptive error msg for both using the package as a module or with the YAML when resource creation is attempted but the resource exists. 