### PR TITLE
Fix broken dryrun option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,17 @@ For example, if you have a YAML file that defines an Organization -> Workspace -
 
 ### Using `tw` specific CLI options
 
+`tw` specific CLI options can be specified with the `--cli=` flag:
+
+```
+twkit file.yaml --cli="--arg1 --arg2"
+```
+
+You can find the full list of options by running `tw -h`.
+
 The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with the `--insecure` flag.
 
-To use `tw` specific CLI options such as `--insecure` (you can find the full list of options by running `tw -h`), use the `--cli=` flag, followed by the options you would like to use enclosed in double quotes.
+To use `tw` specific CLI options such as `--insecure`, use the `--cli=` flag, followed by the options you would like to use enclosed in double quotes.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For example:
 twkit file.yaml --cli="--insecure"
 ```
 
-To use an SSL certificate that it is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option enclosed in double quotes to `twkit` as you would to `tw`, preceded by `--cli=`.
+To use an SSL certificate that is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option enclosed in double quotes to `twkit` as you would to `tw`, preceded by `--cli=`.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,54 @@ Create a Tower access token using the [Nextflow Tower](https://tower.nf/) web in
 export TOWER_ACCESS_TOKEN=<your access token>
 ```
 
+## Usage
+
+Use the -h or --help parameter to list the available commands and their associated options:
+
+```
+twkit -h
+```
+
+### Dryrun
+
+To print the commands that would executed with `tw` when using a YAML file, you can run `twkit` with the `--dryrun` flag:
+
+```
+twkit file.yaml --dryrun
+```
+
+### Recursively delete
+
+Instead of adding or creating resources, you can recursively delete resources in your YAML file by specifying the `--delete` flag:
+
+```
+twkit file.yaml --delete
+```
+
+For example, if you have a YAML file that defines an Organization -> Workspace -> Team -> Credentials -> Compute Environment that have already been created, with the `--delete` flag, `twkit` will recursively delete the Compute Environment -> Credentials -> Team -> Workspace -> Organization.
+
+### Using `tw` specific CLI options
+
+The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with the `--insecure` flag.
+
+To use `tw` specific CLI options such as `--insecure` (you can find the full list of options by running `tw -h`), use the `--cli=` flag, followed by the options you would like to use enclosed in double quotes.
+
+For example:
+
+```
+twkit file.yaml --cli="--insecure"
+```
+
+To use an SSL certificate that it is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option enclosed in double quotes to `twkit` as you would to `tw`, preceded by `--cli=`.
+
+For example:
+
+```
+twkit hello-world-config.yml --cli="-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts"
+```
+
+<b>Note</b>: Use of `--verbose` option for the `tw` CLI is currently not supported by `twkit`. Supplying `--cli="--verbose"` will raise an error.
+
 ## Quick start
 
 You must provide a YAML file that defines the options for each of the entities you would like to create in Nextflow Tower.
@@ -76,19 +124,6 @@ You will need to have an account on Nextflow Tower (see [Plans and pricing](http
 
    ```
    twkit hello-world-config.yml
-   ```
-
-   <b>Note</b>: The Tower CLI expects to connect to a Tower instance that is secured by a TLS certificate. If your Tower instance does not present a certificate, you will need to qualify and run your `tw` commands with `--cli` followed by the `--insecure` flag. For example:
-
-   ```
-   twkit hello-world-config.yml --cli "--insecure"
-   ```
-
-   To use an SSL certificate that it is not accepted by the default Java certificate authorities and specify a custom `cacerts` store as accepted by the `tw` CLI, you can specify the `-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts` option enclosed in double quotes to `twkit` as you would to `tw`, preceded by `--cli` flag to indicate use of `tw` specific CLI options. For example:
-
-   ```
-   twkit hello-world-config.yml --cli "-Djavax.net.ssl.trustStore=/absolute/path/to/cacerts"
-
    ```
 
 3. Login to your Tower instance and check the Runs page in the appropriate Workspace for the pipeline you just launched!

--- a/twkit/cli.py
+++ b/twkit/cli.py
@@ -44,9 +44,8 @@ def parse_args():
         "--cli",
         dest="cli_args",
         type=str,
-        nargs="+",
         help="Additional arguments to pass to the Tower"
-        "CLI enclosed in double quotes (e.g. '--cli \"--insecure\"')",
+        "CLI enclosed in double quotes (e.g. '--cli=\"--insecure\"')",
     )
     return parser.parse_args()
 
@@ -112,9 +111,12 @@ class BlockParser:
 def main():
     options = parse_args()
     logging.basicConfig(level=options.log_level)
-    cli_args_list = options.cli_args[0].split()
+
+    # Parse CLI arguments into a list
+    cli_args_list = options.cli_args.split() if options.cli_args else []
 
     tw = tower.Tower(cli_args=cli_args_list, dryrun=options.dryrun)
+
     block_manager = BlockParser(
         tw,
         [

--- a/twkit/tower.py
+++ b/twkit/tower.py
@@ -27,7 +27,6 @@ class Tower:
             command = ["tw"]
 
             # Prepend the CLI args if present
-            # command.extend(self.tw_instance.cli_args)
             command = self.cmd.split()
             command.extend(args)
             return self.tw_instance._tw_run(command, **kwargs)
@@ -65,11 +64,13 @@ class Tower:
             command.append(f"--params-file={params_path}")
 
         full_cmd = " ".join(arg if "$" in arg else shlex.quote(arg) for arg in command)
-        logging.debug(f" Running command: {full_cmd}\n")
 
         # Skip if --dryrun
         if self.dryrun:
+            logging.debug(f" DRYRUN: Running command: {full_cmd}\n")
             return
+        else:
+            logging.debug(f" Running command: {full_cmd}\n")
 
         # Run the command and return the stdout
         process = subprocess.Popen(

--- a/twkit/utils.py
+++ b/twkit/utils.py
@@ -48,6 +48,9 @@ def check_if_exists(json_data, namekey, namevalue):
     Wrapper around find_key_value_in_dict() to validate that a resource was
     created successfully in Tower by looking for the name and value.
     """
+    if not json_data:
+        return False
+
     data = json.loads(json_data)
     if find_key_value_in_dict(data, namekey, namevalue, return_key=None):
         return True


### PR DESCRIPTION
Re #49 where `--dryrun` returns JSON errors. Additionally adds test for `--dryrun` and another for CLI args like custom SSL cert stores.